### PR TITLE
[diopter.sanitizer] Revamp the sanitizer

### DIFF
--- a/diopter/generator.py
+++ b/diopter/generator.py
@@ -5,11 +5,14 @@ from multiprocessing import cpu_count
 from random import randint
 from typing import Iterator, Optional
 
-from diopter.sanitizer import sanitize_code as sanitize
+from diopter.sanitizer import Sanitizer
 from diopter.compiler import SourceProgram, Language
 
 
 class Generator(ABC):
+    def __init__(self, sanitizer: Sanitizer):
+        self.sanitizer = sanitizer
+
     @abstractmethod
     def generate_program_impl(self) -> SourceProgram:
         """Concrete subclasses must implement this
@@ -28,8 +31,6 @@ class Generator(ABC):
         Returns:
             bool: if the program is good(sanitized)
         """
-        # TODO: the sanitizer should be configurable, e.g., only warnings + UB
-        # one solution is to pass a sanitizer object that checks SourcePrograms
         pass
 
     def generate_program(self) -> SourceProgram:
@@ -97,22 +98,21 @@ class CSmithGenerator(Generator):
 
     def __init__(
         self,
+        sanitizer: Sanitizer,
         csmith: Optional[str] = None,
         include_path: Optional[str] = None,
         options_pool: Optional[list[str]] = None,
         minimum_length: int = 10000,
         maximum_length: int = 50000,
-        clang: str = "clang",
-        gcc: str = "gcc",
-        ccomp: str = "ccomp",
     ):
         """
         Args:
-            self:
+            sanitizer (Sanitizer):
+                used to sanitize and discard generated code
             csmith (Optional[str]):
                 Path to csmith executable, if empty "csmith" will be used
             include_path (Optional[str]):
-                csmith include path, if None "/usr/include/csmith-2.3.0" is used
+                csmith include path, if empty "/usr/include/csmith-2.3.0" will be used
             options_pool (Optional[list[str]]):
                 csmith options that will be randomly selected,
                 if empty default_options_pool will be used
@@ -120,18 +120,10 @@ class CSmithGenerator(Generator):
                 The minimum length of a generated test case in characters.
             maximum_length (int):
                 The maximum length of a generated test case in characters.
-            clang (str):
-                Path to executable or name in $PATH to clang. Default: "clang".
-            gcc (str):
-                Path to executable or name in $PATH to gcc. Default: "gcc".
-            ccomp (str):
-                Path to executable or name in $PATH to compcert. Default: "ccomp".
         """
+        super().__init__(sanitizer)
         self.minimum_length = minimum_length
         self.maximum_length = maximum_length
-        self.clang = clang
-        self.gcc = gcc
-        self.ccomp = ccomp
         self.csmith = csmith if csmith else "csmith"
         self.options = (
             options_pool if options_pool else CSmithGenerator.default_options_pool
@@ -172,6 +164,4 @@ class CSmithGenerator(Generator):
             or len(program.code) > self.maximum_length
         ):
             return False
-        return sanitize(
-            self.gcc, self.clang, self.ccomp, program.code, f"-I {self.include_path}"
-        )
+        return bool(self.sanitizer.sanitize(program))


### PR DESCRIPTION
The sanitizer now operates on SourcePrograms and tries to use sane defaults (e.g., if gcc/clang are unspecified, the system ones will be used). It is also more configurable: instead of always running all checks, a subset of them can be used.