### PR TITLE
[CSmithGenerator] Randomly use --ccomp

### DIFF
--- a/diopter/generator.py
+++ b/diopter/generator.py
@@ -87,6 +87,7 @@ class CSmithGenerator(Generator):
         "return-structs",
         "arg-structs",
         "dangling-global-pointers",
+        "ccomp",
     ]
     fixed_options = [
         "--no-unions",
@@ -94,7 +95,6 @@ class CSmithGenerator(Generator):
         "--no-argc",
         "--no-volatiles",
         "--no-volatile-pointers",
-        "--ccomp",
     ]
 
     def __init__(


### PR DESCRIPTION
Instead always passing --ccomp to csmith only do it some of the times.