### PR TITLE
Use TMPDIR env for creduce

### DIFF
--- a/diopter/reducer.py
+++ b/diopter/reducer.py
@@ -147,6 +147,7 @@ class Reducer:
                     creduce_cmd,
                     log_file=log_file if log_file else stderr,
                     working_dir=Path(tmpdir),
+                    additional_env={"TMPDIR": tmpdir}
                 )
             except subprocess.CalledProcessError as e:
                 logging.info(f"Failed to reduce code. Exception: {e}")


### PR DESCRIPTION
Currently, the creduce files are not cleaned. TMPDIR env should be used to specify the working dir of reduce. https://github.com/csmith-project/creduce/blob/master/README.md