### PR TITLE
Support Clang's memory sanitizer

### DIFF
--- a/diopter/sanitizer.py
+++ b/diopter/sanitizer.py
@@ -360,7 +360,13 @@ class Sanitizer:
 
             # Run the instrumented binary
             try:
-                run_cmd(str(result.output.filename), timeout=self.execution_timeout)
+                run_cmd(
+                    str(result.output.filename),
+                    timeout=self.execution_timeout,
+                    additional_env={
+                        "ASAN_OPTIONS": "detect_stack_use_after_return=1",
+                    },
+                )
             except subprocess.TimeoutExpired:
                 if self.debug:
                     print("Compilation timed out")

--- a/diopter/sanitizer.py
+++ b/diopter/sanitizer.py
@@ -162,7 +162,7 @@ class Sanitizer:
         clang: CompilerExe | None = None,
         ccomp: CComp | None = None,
         check_warnings_opt_level: OptLevel = OptLevel.O3,
-        sanitizer_opt_level: OptLevel = OptLevel.O1,
+        sanitizer_opt_level: OptLevel = OptLevel.O0,
         checked_warnings: tuple[str, ...] | None = None,
         use_gnu2x_if_available: bool = True,
         compilation_timeout: int = 8,
@@ -345,7 +345,6 @@ class Sanitizer:
                         "-Wno-builtin-declaration-mismatch",
                         "-fsanitize=" + sanitizer_flag,
                         "-fno-sanitize-recover=all",
-                        "-O0",
                     ),
                     timeout=self.compilation_timeout,
                 )

--- a/tests/sanitizer_test.py
+++ b/tests/sanitizer_test.py
@@ -63,12 +63,14 @@ def test_check_for_compiler_warnings() -> None:
         '{int a = 2147483647;printf("a+1: %d", a+1);}',
     ],
 )
-def test_sanitizer(code: str) -> None:
+def test_ub_and_address_sanitizer(code: str) -> None:
     clang = find_clang()
     assert clang, "Could not find a clang executable"
     san = Sanitizer(clang=clang, debug=True)
     p = SourceProgram(code=code, language=Language.C)
-    assert san.check_for_ub_and_address_sanitizer_errors(p).ub_address_sanitizer_failed
+    assert san.check_for_sanitizer_errors(
+        p, sanitizer_flag="undefined,address"
+    ).sanitizer_failed
 
 
 @pytest.mark.parametrize(
@@ -87,7 +89,7 @@ def test_memory_sanitizer(code: str) -> None:
         debug=True,
     )
     p = SourceProgram(code=code, language=Language.C)
-    assert san.check_for_memory_sanitizer_errors(p).memory_sanitizer_failed
+    assert san.check_for_sanitizer_errors(p, sanitizer_flag="memory").sanitizer_failed
 
 
 if __name__ == "__main__":

--- a/tests/sanitizer_test.py
+++ b/tests/sanitizer_test.py
@@ -71,5 +71,24 @@ def test_sanitizer(code: str) -> None:
     assert san.check_for_ub_and_address_sanitizer_errors(p).ub_address_sanitizer_failed
 
 
+@pytest.mark.parametrize(
+    "code",
+    [
+        "int main(){ int a[1]; if (a[0]) return 1; return 0;}",
+    ],
+)
+def test_memory_sanitizer(code: str) -> None:
+    clang = find_clang()
+    assert clang, "Could not find a clang executable"
+    san = Sanitizer(
+        clang=clang,
+        use_ub_address_sanitizer=False,
+        use_memory_sanitizer=True,
+        debug=True,
+    )
+    p = SourceProgram(code=code, language=Language.C)
+    assert san.check_for_memory_sanitizer_errors(p).memory_sanitizer_failed
+
+
 if __name__ == "__main__":
     test_check_for_compiler_warnings()

--- a/tests/sanitizer_test.py
+++ b/tests/sanitizer_test.py
@@ -61,6 +61,7 @@ def test_check_for_compiler_warnings() -> None:
         "int main(){ int a[1] = {0}; return a[1];}",
         "int printf(const char *, ...); int main()"
         '{int a = 2147483647;printf("a+1: %d", a+1);}',
+        "int *g;" "void foo(int x) { g = &x;}" "int main(){foo(0); return *g;}",
     ],
 )
 def test_ub_and_address_sanitizer(code: str) -> None:


### PR DESCRIPTION
For now, use-of-uninitialized memory is not checked by diopter's sanitizer. 
For example,
```C
int main() {
  int a[1];
  if (a[0])
    return 1;
  return 0;
}
```
This test case can pass diopter's sanitizer checks.