### PR TITLE
Disable leak sanitizer

### DIFF
--- a/diopter/sanitizer.py
+++ b/diopter/sanitizer.py
@@ -365,6 +365,7 @@ class Sanitizer:
                     timeout=self.execution_timeout,
                     additional_env={
                         "ASAN_OPTIONS": "detect_stack_use_after_return=1",
+                        "ASAN_OPTIONS": "detect_leaks=0",
                     },
                 )
             except subprocess.TimeoutExpired:


### PR DESCRIPTION
ASAN be default detects memory leaks, which are not actually undefined behaviors. https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer

We previously did not encounter this issue because csmith does not use any heap memory.

This PR disable leak sanitizer as I'm adding heap memory support to program generators.